### PR TITLE
fine tune copies; fix klog

### DIFF
--- a/cmd/hostpathplugin/main.go
+++ b/cmd/hostpathplugin/main.go
@@ -25,22 +25,20 @@ import (
 
 	"github.com/openshift/csi-driver-projected-resource/pkg/controller"
 	"github.com/openshift/csi-driver-projected-resource/pkg/hostpath"
-)
 
-func init() {
-	flag.Set("logtostderr", "true")
-}
+	"k8s.io/klog/v2"
+)
 
 var (
 	endpoint          = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	driverName        = flag.String("drivername", "projected-resource-csi-driver.openshift.io", "name of the driver")
 	nodeID            = flag.String("nodeid", "", "node id")
 	maxVolumesPerNode = flag.Int64("maxvolumespernode", 0, "limit of volumes per node")
-	// Set by the build process
-	version = ""
+	version           = ""
 )
 
 func main() {
+	klog.InitFlags(nil)
 	flag.Parse()
 
 	handle()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	objcache "github.com/openshift/csi-driver-projected-resource/pkg/cache"
 	"github.com/openshift/csi-driver-projected-resource/pkg/client"

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	utilexec "k8s.io/utils/exec"
 )
 

--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -151,29 +151,20 @@ func createFile(path string, buf []byte) {
 	file.Write(buf)
 }
 
-func commonUpsertRanger(volPath, podPath string, key, value interface{}) bool {
+func commonUpsertRanger(podPath string, key, value interface{}) bool {
 	buf, err := json.MarshalIndent(value, "", "    ")
 	if err != nil {
 		klog.Errorf("error marshalling: %s", err.Error())
 		return true
 	}
-	volFilePath := filepath.Join(volPath, fmt.Sprintf("%s", key))
-	klog.V(4).Infof("create/update file %s", volFilePath)
-	// since os.Create truncates existing files (i.e. it becomes a replace operation),
-	// we employ the same logic for create and update; but if we change the file
-	// system interaction mechanism such that create and update are treated differently, we'll
-	// need separate callbacks for each
-	createFile(volFilePath, buf)
-	// now update the pod mount
 	podFilePath := filepath.Join(podPath, fmt.Sprintf("%s", key))
+	klog.V(4).Infof("create/update file %s", podFilePath)
 	createFile(podFilePath, buf)
 	return true
 }
 
-func commonDeleteRanger(volPath, podPath string, key interface{}) bool {
-	volFilePath := filepath.Join(volPath, fmt.Sprintf("%s", key))
+func commonDeleteRanger(podPath string, key interface{}) bool {
 	podFilePath := filepath.Join(podPath, fmt.Sprintf("%s", key))
-	os.Remove(volFilePath)
 	os.Remove(podFilePath)
 	return true
 }
@@ -188,13 +179,12 @@ func (hp *hostPath) mapVolumeToPod(hpv *hostPathVolume) error {
 	if err != nil {
 		return err
 	}
-	volConfigMapsPath := filepath.Join(hpv.VolPath, "configmaps")
 	upsertRangerCM := func(key, value interface{}) bool {
-		return commonUpsertRanger(volConfigMapsPath, podConfigMapsPath, key, value)
+		return commonUpsertRanger(podConfigMapsPath, key, value)
 	}
 	objcache.RegisterConfigMapUpsertCallback(hpv.VolID, upsertRangerCM)
 	deleteRangerCM := func(key, value interface{}) bool {
-		return commonDeleteRanger(volConfigMapsPath, podConfigMapsPath, key)
+		return commonDeleteRanger(podConfigMapsPath, key)
 	}
 	objcache.RegisterConfigMapDeleteCallback(hpv.VolID, deleteRangerCM)
 
@@ -203,13 +193,12 @@ func (hp *hostPath) mapVolumeToPod(hpv *hostPathVolume) error {
 	if err != nil {
 		return err
 	}
-	volSecretsPath := filepath.Join(hpv.VolPath, "secrets")
 	upsertRangerSec := func(key, value interface{}) bool {
-		return commonUpsertRanger(volSecretsPath, podSecretsPath, key, value)
+		return commonUpsertRanger(podSecretsPath, key, value)
 	}
 	objcache.RegisterSecretUpsertCallback(hpv.VolID, upsertRangerSec)
 	deleteRangerSec := func(key, value interface{}) bool {
-		return commonDeleteRanger(volSecretsPath, podSecretsPath, key)
+		return commonDeleteRanger(podSecretsPath, key)
 	}
 	objcache.RegisterSecretDeleteCallback(hpv.VolID, deleteRangerSec)
 	return nil
@@ -223,21 +212,6 @@ func (hp *hostPath) createHostpathVolume(volID, podNamespace, podName, podUID, p
 	switch volAccessType {
 	case mountAccess:
 		err := os.MkdirAll(volPath, 0777)
-		if err != nil {
-			return nil, err
-		}
-		volConfigMapsPath := filepath.Join(volPath, "configmaps")
-		// for now, since os.MkdirAll does nothing and returns no error when the path already
-		// exists, we have a common path for both create and update; but if we change the file
-		// system interaction mechanism such that create and update are treated differently, we'll
-		// need separate callbacks for each
-		err = os.MkdirAll(volConfigMapsPath, 0777)
-		if err != nil {
-			return nil, err
-		}
-
-		volSecretsPath := filepath.Join(volPath, "secrets")
-		err = os.MkdirAll(volSecretsPath, 0777)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/hostpath/hostpath_test.go
+++ b/pkg/hostpath/hostpath_test.go
@@ -67,15 +67,7 @@ func TestCreateHostPathVolume(t *testing.T) {
 	defer os.RemoveAll(targetPath)
 	secret, cm := primeVolume(hp, targetPath, t)
 
-	foundSecret, foundConfigMap := findSharedItems(dir, t)
-	if !foundSecret {
-		t.Fatalf("did not find secret in driver path")
-	}
-	if !foundConfigMap {
-		t.Fatalf("did not find configmap in driver path")
-	}
-
-	foundSecret, foundConfigMap = findSharedItems(targetPath, t)
+	foundSecret, foundConfigMap := findSharedItems(targetPath, t)
 	if !foundSecret {
 		t.Fatalf("did not find secret in mount path")
 	}

--- a/pkg/hostpath/identityserver.go
+++ b/pkg/hostpath/identityserver.go
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type identityServer struct {

--- a/pkg/hostpath/nodeserver.go
+++ b/pkg/hostpath/nodeserver.go
@@ -150,11 +150,8 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	klog.V(4).Infof("NodePublishVolume %v\nfstype %v\ndevice %v\nvolumeId %v\nattributes %v\nmountflags %v\n",
 		targetPath, fsType, deviceId, volumeId, attrib, mountFlags)
 
-	options := []string{} //"bind"}
-	//if readOnly {
-	//	options = append(options, "ro")
-	//}
-	path := ns.hp.getVolumePath(volumeId, podNamespace, podName, podUID, podSA)
+	options := []string{}
+	path := vol.VolPath
 
 	// NOTE: so our intent here is to have a separate tmpfs per pod; through experimentation
 	// and corroboration with OpenShift storage SMEs, a separate tmpfs per pod
@@ -166,8 +163,8 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// The various bits that work in concert to achieve this
 	// - the use of emptyDir with a medium of Memory in this drivers Deployment is all that is needed to get tmpfs
 	// - do not use the "bind" option, that reuses existing dirs/filesystems vs. creating new tmpfs
-	// - without bind, we have to specify an fstype of tmpfs, or we get errors on the Mount about the fs not being
-	//   block access
+	// - without bind, we have to specify an fstype of tmpfs and path for the mount source, or we get errors on the
+	//   Mount about the fs not being  block access
 	// - that said,  testing confirmed using fstype of tmpfs on hostpath/xfs volumes still results in the target
 	//   being xfs and not tmpfs
 	// - with the lack of a bind option, and each pod getting its own tmpfs we have to copy the data from our emptydir

--- a/pkg/hostpath/nodeserver.go
+++ b/pkg/hostpath/nodeserver.go
@@ -27,7 +27,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/mount"
 )
 

--- a/pkg/hostpath/server.go
+++ b/pkg/hostpath/server.go
@@ -29,7 +29,7 @@ import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 func NewNonBlockingGRPCServer() *nonBlockingGRPCServer {


### PR DESCRIPTION
/assign @adambkaplan 

discovered the glog to klog port was not quite right, and it actually prevented the driver from coming up;
fixed that, along with verifying klog.V(0), klog.V(1), klog.V(2) up through klog.(5) work as expected now

also took another round of simplification of the host path / pod path mount flow

in particular:
- we just need to create the hostpath vol dir, we do not need to copy data there, since we have to copy the data to the pod tmpfs anyway because of our non-bind, 1 tmpfs per 1 pod, make selinux happy approach
- we do need to at least create the hostpath vol dir in its emptydir/medium: memory or else the mount fails with the non block access support stuff 

once we get consensus and merge this, I'll move onto

- move to the quay.io image ... mirroring should be there by then
- move on to projected resourece api

@coreydaley fyi