### PR TITLE
fix delete of configmap/secret with keys

### DIFF
--- a/pkg/hostpath/hostpath.go
+++ b/pkg/hostpath/hostpath.go
@@ -216,7 +216,7 @@ func commonDeleteRanger(podPath, filter string, key interface{}) bool {
 		return true
 	}
 	podFilePath := filepath.Join(podPath, fmt.Sprintf("%s", key))
-	os.Remove(podFilePath)
+	os.RemoveAll(podFilePath)
 	return true
 }
 

--- a/pkg/hostpath/nodeserver_test.go
+++ b/pkg/hostpath/nodeserver_test.go
@@ -40,8 +40,11 @@ func (f *fakeShareLister) Get(name string) (*sharev1alpha1.Share, error) {
 	return f.share, nil
 }
 
-func testNodeServer() (*nodeServer, string, string, error) {
-	hp, tmpDir, volPathTmpDir, err := testHostPathDriver()
+func testNodeServer(testName string) (*nodeServer, string, string, error) {
+	if strings.Contains(testName, "/") {
+		testName = strings.Split(testName, "/")[0]
+	}
+	hp, tmpDir, volPathTmpDir, err := testHostPathDriver(testName)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -359,7 +362,7 @@ func TestNodePublishVolume(t *testing.T) {
 			if test.nodePublishVolReq.TargetPath != "" {
 				defer os.RemoveAll(test.nodePublishVolReq.TargetPath)
 			}
-			ns, tmpDir, volPath, err := testNodeServer()
+			ns, tmpDir, volPath, err := testNodeServer(t.Name())
 			if err != nil {
 				t.Fatalf("unexpected err %s", err.Error())
 			}


### PR DESCRIPTION
the unit tests were not creating actual files resulting from k/v's in the configmap/secret data maps

hence the need for an `os.RemoveAll` vs. the existing `os.Remove` was missed

also did some cleanup around better unit test concurrency and string literals