### PR TITLE
readme updates on k8s vol api support

### DIFF
--- a/examples/csi-app.yaml
+++ b/examples/csi-app.yaml
@@ -7,7 +7,7 @@ spec:
   serviceAccountName: default
   containers:
     - name: my-frontend
-      image: busybox
+      image: quay.io/quay/busybox
       volumeMounts:
         - mountPath: "/data"
           name: my-csi-volume


### PR DESCRIPTION
in line with not providing a full CSI volume implementation per the EP, I've added some explicity what we do and do not support from a k8s volume API perspective to the README

/assign @alicerum 