### PR TITLE
BUILD-261: Add release version to install instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,34 @@
 
 1. Grant `cluster-admin` permissions to the current user.
 
-## Installing from a local clone of this repository (only developer preview level support)
+## Installation (developer preview)
+
+### Installing from the release page
+
+Run the following command, providing an available release version.
+Available versions can be found on the [releases page](https://github.com/openshift/csi-driver-projected-resource/releases).
+
+```bash
+$ export RELEASE_VERSION="v0.4.8-rc.0"
+$ oc apply -f "https://github.com/openshift/csi-driver-projected-resource/releases/download/${RELEASE_VERSION}/release.yaml"
+```
+
+You should see an output similar to the following printed on the terminal showing the creation or modification of the various
+Kubernetes resources:
+
+```shell
+namespace/csi-driver-projected-resource created
+customresourcedefinition.apiextensions.k8s.io/shares.projectedresource.storage.openshift.io created
+serviceaccount/csi-driver-projected-resource-plugin created
+clusterrole.rbac.authorization.k8s.io/projected-resource-secret-configmap-share-watch-sar-create created
+clusterrolebinding.rbac.authorization.k8s.io/projected-resource-privileged created
+clusterrolebinding.rbac.authorization.k8s.io/projected-resource-secret-configmap-share-watch-sar-create created
+csidriver.storage.k8s.io/csi-driver-projected-resource.openshift.io created
+service/csi-hostpathplugin created
+daemonset.apps/csi-hostpathplugin created
+```
+
+### Installing from a local clone of this repository
 
 1. Run the following command
 
@@ -16,7 +43,7 @@
 ```
 
 You should see an output similar to the following printed on the terminal showing the creation or modification of the various
-Kubernetes resource:
+Kubernetes resources:
 
 ```shell
 deploying hostpath components
@@ -46,7 +73,7 @@ daemonset.apps/csi-hostpathplugin created
 16:21:25 waiting for hostpath deployment to complete, attempt #0
 ```
 
-## Installing from the master branch of this repository (only developer preview level support)
+### Installing from the default branch of this repository
 
 1. Run the following command
 
@@ -61,7 +88,7 @@ oc apply -f --filename https://raw.githubusercontent.com/openshift/csi-driver-pr
 ```
 
 You should see an output similar to the following printed on the terminal showing the creation or modification of the various
-Kubernetes resource:
+Kubernetes resources:
 
 ```shell
 namespace/csi-driver-projected-resource created
@@ -76,7 +103,7 @@ daemonset.apps/csi-hostpathplugin created
 ```
 
 
-## Installing from a release specific branch of this repository (only developer preview level support)
+### Installing from a release specific branch of this repository
 
 1. Run the following command
 
@@ -91,31 +118,7 @@ oc apply -f --filename https://raw.githubusercontent.com/openshift/csi-driver-pr
 ```
 
 You should see an output similar to the following printed on the terminal showing the creation or modification of the various
-Kubernetes resource:
-
-```shell
-namespace/csi-driver-projected-resource created
-customresourcedefinition.apiextensions.k8s.io/shares.projectedresource.storage.openshift.io created
-serviceaccount/csi-driver-projected-resource-plugin created
-clusterrole.rbac.authorization.k8s.io/projected-resource-secret-configmap-share-watch-sar-create created
-clusterrolebinding.rbac.authorization.k8s.io/projected-resource-privileged created
-clusterrolebinding.rbac.authorization.k8s.io/projected-resource-secret-configmap-share-watch-sar-create created
-csidriver.storage.k8s.io/csi-driver-projected-resource.openshift.io created
-service/csi-hostpathplugin created
-daemonset.apps/csi-hostpathplugin created
-```
-
-
-## Installing from the release page  (only developer preview level support)
-
-1. Run the following command
-
-```bash
-oc apply -f --filename https://github.com/openshift/csi-driver-projected-resource/releases/download/v0.1.0/release.yaml
-```
-
-You should see an output similar to the following printed on the terminal showing the creation or modification of the various
-Kubernetes resource:
+Kubernetes resources:
 
 ```shell
 namespace/csi-driver-projected-resource created
@@ -132,8 +135,8 @@ daemonset.apps/csi-hostpathplugin created
 
 ## Validate the installation
 
-First, let's validate the deployment.  Ensure all expected pods are running for the driver plugin, which in a
-3 node OCP cluster will look something like:
+Every node should have a pod running the driver plugin in the namespace `csi-driver-projected-resource`.
+On a 3 node OCP cluster, this will look something like:
 
 ```shell
 $ oc get pods -n csi-driver-projected-resource


### PR DESCRIPTION
- Update the install instructions to use the current dev preview release
  tag for the release.yaml URL.
- Restructure the install instrucitons to suggest the release.yaml
  approach first.
- Update the validation instructions.